### PR TITLE
Fix: [i had fixed the Code block overflow issue in pre section on hom…

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -172,8 +172,8 @@ export const LandingPage = () => {
                 <span className="ml-2 text-xs text-gray-400 font-mono">VS Code + LeetCode</span>
               </div>
               {/* Code content */}
-              <div className="px-6 pt-4 pb-2">
-                <pre className="font-mono text-green-400 text-sm leading-relaxed mb-2 bg-transparent p-0">
+              <div className="px-4 pt-4 pb-2">
+                <pre className="font-mono text-green-400 text-sm leading-relaxed mb-2 bg-transparent px-2 py-1 whitespace-pre-wrap break-words">
                   {`// Day 1: Binary Search + React Setup
 function binarySearch(arr, target) {
   return recursiveSearch(arr, 0, arr.length-1, target);


### PR DESCRIPTION
…e page] (#11)

## 📥 Pull Request

### Description
Resolved an issue where the code snippet inside the `<pre>` tag in home page  was overflowing outside its container and getting cut off visually.
Fixes # (11)

Updated <pre> tag with class: `break-words whitespace-pre-wrap` to prevent overflow.
### Video or Photo (mandatory)
**_before the change_**
![PHOTO-2025-07-22-14-20-34](https://github.com/user-attachments/assets/d1284611-572e-46b2-98c4-0664e7fb2ddf)




**_after change_** 
<img width="549" height="453" alt="Screenshot 2025-07-22 at 1 53 41 PM" src="https://github.com/user-attachments/assets/67951915-46de-477b-89bc-29c2450e30ad" />



### Checklist:

- [ ok] I have mentioned the issue number in my Pull Request.
- [ ok] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md` if its a new page/tech stack
- [ ok] I have gone through the `CONTRIBUTING.md` file before contributing


**Do you follow me? (Optional 😊)** 
<!-- Just for fun and connection! -->

- [ i will follow u] Yes, I follow you on GitHub  
- [ ] Not yet, but I will now! 😄
