### PR TITLE
Add DevOps learning path initial files

### DIFF
--- a/docs/devops/01-intro.md
+++ b/docs/devops/01-intro.md
@@ -1,0 +1,24 @@
+---
+title: "DevOps Introduction"
+slug: learning-paths/devops/01-intro
+---
+
+# Introduction to DevOps
+
+DevOps combines development (Dev) and operations (Ops) to enable organizations to deliver applications and services at high velocity. It aligns development, IT operations, and quality assurance teams through automation, collaboration, and continuous feedback.
+
+## Why DevOps?
+
+- **Faster delivery** of features
+- Increased efficiency through automation
+- Improved collaboration between development and operations
+- Better product quality and reliability
+
+## Key Pillars
+
+1. **Collaboration:** Breaking down silos between teams
+2. **Automation:** Streamlining processes like testing and deployment
+3. **Continuous Integration and Delivery (CI/CD):** Frequent, reliable releases
+4. **Monitoring and Feedback:** Rapid response to issues
+
+In the following modules, we'll explore the core components and tools in the DevOps journey!

--- a/docs/devops/02-ci-cd.md
+++ b/docs/devops/02-ci-cd.md
@@ -1,0 +1,31 @@
+---
+title: "CI/CD Concepts"
+slug: learning-paths/devops/02-ci-cd
+---
+
+# Continuous Integration & Continuous Deployment (CI/CD)
+
+CI/CD is a cornerstone of effective DevOps, focusing on the automation of code integration, testing, and deployment.
+
+## What is Continuous Integration (CI)?
+
+- Developers merge code changes into a shared repository frequently.
+- Automated builds and tests verify every change.
+- Reduces integration issues and delivers quality code faster.
+
+**Popular CI Tools:** GitHub Actions, Jenkins, Travis CI, CircleCI.
+
+## What is Continuous Deployment/Delivery (CD)?
+
+- **Continuous Delivery**: Automated delivery of code to a staging or production environment after passing tests.
+- **Continuous Deployment**: Every change that passes automated tests is deployed automatically to production.
+
+**Popular CD Tools:** Spinnaker, ArgoCD, GitLab CI/CD.
+
+## Common Pipeline Stages
+
+1. *Build*: Compile and check code
+2. *Test*: Automated unit and integration tests
+3. *Deploy*: Ship code to production
+
+CI/CD bridges the gap between development and operations, ensuring faster and safer releases.

--- a/docs/devops/03-containers.md
+++ b/docs/devops/03-containers.md
@@ -1,0 +1,35 @@
+---
+title: "Containers & Orchestration"
+slug: learning-paths/devops/03-containers
+---
+
+# Containers & Orchestration
+
+Containers package applications and dependencies together, making them portable and consistent across different environments.
+
+## What Are Containers?
+
+- Lightweight, standalone, and executable packages.
+- Encapsulate code, runtime, libraries, and configs.
+- *Docker* is the most widely-used container runtime.
+
+## Why Use Containers?
+
+- **Consistency** between dev and prod environments
+- Fast, scalable, and efficient deployments
+- Isolation and security
+
+## Orchestration with Kubernetes
+
+As applications grow, managing many containers becomes challenging. Orchestration automates deployment, scaling, and management.
+
+- **Kubernetes** is the leading orchestration platform.
+- Coordinates containers across multiple machines.
+- Handles load balancing, scaling, rollouts, health checks.
+
+## Other Tools
+
+- Docker Compose (development)
+- Amazon ECS, Azure AKS, Google GKE (managed Kubernetes)
+
+Containers and orchestration are vital for modern DevOps and microservices architectures!

--- a/docs/devops/04-monitoring.md
+++ b/docs/devops/04-monitoring.md
@@ -1,0 +1,38 @@
+---
+title: "Monitoring & Observability"
+slug: learning-paths/devops/04-monitoring
+---
+
+# Monitoring & Observability
+
+Monitoring helps you track applications, infrastructure, and services for health, performance, and reliability.
+
+## Monitoring vs. Observability
+
+- **Monitoring:** Tracking metrics (CPU, memory, errors) and alerting for issues
+- **Observability:** Understanding the internal state of systems by examining logs, metrics, and traces
+
+## Why Is Monitoring Important?
+
+- Detect issues early
+- Ensure high availability and performance
+- Provide insights for capacity planning and optimization
+
+## Common Tools
+
+- **Prometheus**: Metric collection and alerting
+- **Grafana**: Visualization dashboards
+- **ELK/EFK Stack**: Log aggregation (Elasticsearch, Logstash/Fluentd, Kibana)
+- **Datadog, New Relic, Splunk**: Commercial solutions
+
+## Core Practices
+
+- Set up baseline monitoring for all services
+- Use dashboards and alerts for critical events
+- Practice incident response and postmortems
+
+A robust monitoring and observability setup helps teams respond quickly and deliver high-quality software!
+
+---
+
+Congratulations! You’ve completed the DevOps basics path. Explore more advanced topics as you continue your journey.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -28,6 +28,20 @@ const sidebars: SidebarsConfig = {
     },
   ],
    */
+   devopsSidebar: [
+    {
+      type: 'category',
+      label: 'DevOps Learning Path',
+      collapsed: false,
+      items: [
+        // These paths correspond to MDX files under docs/learning-paths/devops/
+        'learning-paths/devops/01-intro',
+        'learning-paths/devops/02-ci-cd',
+        'learning-paths/devops/03-containers',
+        'learning-paths/devops/04-monitoring',
+      ],
+    },
+   ],
 };
 
 export default sidebars;


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR adds a new DevOps Learning Path to the documentation under docs/devops. It introduces an organized set of beginner-friendly modules covering:

Introduction to DevOps

CI/CD concepts

Containers and orchestration

Monitoring and observability

Each topic has its own .md file with structured content.
The sidebar (sidebars.ts) is updated to include the new DevOps Learning Path so it appears correctly in the docs site navigation.

Motivation:
DevOps is an essential part of the modern software life cycle. Including this path helps learners explore continuous delivery, automation, deployment strategies, and operational excellence, making the documentation more comprehensive.

Dependencies:
No new dependencies were introduced.

Fixes # (issue number): **#51

### Checklist:

- [ ] I have mentioned the issue number in my Pull Request.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md` if its a new page/tech stack
- [ ] I have gone through the `CONTRIBUTING.md` file before contributing


**Do you follow me? (Optional 😊)** 
<!-- Just for fun and connection! -->

- [ ] Yes, I follow you on GitHub  
- [ ] Not yet, but I will now! 😄
