### PR TITLE
#102 feat: scroll to top on logo click if already on homepage

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import styles from './index.module.css';
@@ -46,6 +46,26 @@ const courses = [
 ];
 
 export default function Home(): React.ReactElement {
+  
+   useEffect(() => {
+    const logoEl = document.querySelector(".navbar__title");
+
+    if (!logoEl) return;
+
+    const handleClick = (e: MouseEvent) => {
+      if (window.location.pathname === "/") {
+        e.preventDefault();
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      }
+    };
+
+    logoEl.addEventListener("click", handleClick);
+
+    return () => {
+      logoEl.removeEventListener("click", handleClick);
+    };
+  }, []);
+
   return (
     <Layout
       title="Launch Your Tech Career in 30 Days"


### PR DESCRIPTION
# Related Issue  
Fixes #102

## Description  
Added smooth scroll-to-top functionality when clicking the LearnHub logo, only if the user is already on the homepage (`/`).

# Type of PR  
- [x] Feature enhancement

# Screenshots / videos (if applicable)  

https://github.com/user-attachments/assets/ef3edef5-5bcb-4498-ab59-ea24730decee



## Checklist:  
- [x] I have made this change from my own.  
- [x] I have mentioned the issue number in my Pull Request.  
- [x] I have gone through the `CONTRIBUTING.md` file before contributing  
- [x] I have performed a self-review of my own code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have made corresponding changes to the documentation.  
- [x] My changes generate no new warnings.  
- [x] I have tested the changes thoroughly before submitting this pull request.  
- [x] I have provided relevant issue numbers and screenshots after making the changes.  
