### PR TITLE
fixed footer section on mobile screen

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -94,8 +94,7 @@ const config: Config = {
       ],
     },
     footer: {
-      style: 'dark',
-      
+      style: 'dark', 
       links: [
         {
           title: 'Docs',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -45,7 +45,7 @@
   .footer__link-item {
     display: block;
     text-align: center;
-    width: 100%; /* Stretch link container so it can center text */
+    width: 100%; 
   }
 
   .footer__col {


### PR DESCRIPTION
# Related Issue

## Description
Footer section was not responsive in mobile screens i fixed this issue. Adjusted its width and made the content in the footer center

Fixes #125 

# Type of PR

- [ ] Bug fix

Before:
<img width="246" height="531" alt="Screenshot 2025-07-27 101616" src="https://github.com/user-attachments/assets/6996fab1-20b2-4297-a229-39dc11b277ca" />
After:
<img width="364" height="794" alt="Screenshot 2025-07-27 112502" src="https://github.com/user-attachments/assets/9e1fdc6e-b83e-4f1d-9f51-c95a50a94816" />


## Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] I have mentioned the issue number in my Pull Request.
- [x] I have gone through the `CONTRIBUTING.md` file before contributing
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.
