### PR TITLE
feat: add animated scroll-to-top button with Lucide icon and smooth UX

### DIFF
--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+
+const ScrollToTopButton: React.FC = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      style={{
+        position: "fixed",
+        bottom: "2rem",
+        right: "2rem",
+        backgroundColor: "#2e8555",
+        border: "none",
+        borderRadius: "50%",
+        padding: "0.8rem",
+        boxShadow: "0 4px 12px rgba(0, 0, 0, 0.2)",
+        cursor: "pointer",
+        transition: "transform 0.3s ease, background-color 0.3s ease",
+        zIndex: 9999,
+        animation: "bounceIn 0.5s ease-in-out",
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.transform = "scale(1.1)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.transform = "scale(1)";
+      }}
+      aria-label="Scroll to top"
+    >
+      <ArrowUp color="white" size={24} />
+    </button>
+  );
+};
+
+export default ScrollToTopButton;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import Layout from '@theme/Layout';
 import styles from './index.module.css';
 import { Typewriter } from 'react-simple-typewriter';
 import HomepageFeatures from '../components/HomepageFeatures';
+import ScrollToTopButton from '../components/ScrollToTopButton';
 
 
 
@@ -228,6 +229,7 @@ function binarySearch(arr, target) {
           </div>
         </div>
       </section>
+      <ScrollToTopButton />
     </Layout>
   );
 }


### PR DESCRIPTION

Closes #178 

## Description

This pull request adds a scroll-to-top button that appears when the user scrolls down the page. On click, it smoothly scrolls the page to the top. The button is styled with a modern floating design, includes hover and bounce-in animation effects, and uses the Lucide `ArrowUp` icon for clarity.

This feature improves overall UX by providing users a convenient way to return to the top of page.

# Type of PR

- [ ] Bug fix  
- [x] Feature enhancement  
- [ ] Documentation update  
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)


https://github.com/user-attachments/assets/48414ddc-442a-405b-8744-9358886344d2


## Checklist:

- [x] I have made this change from my own.  
- [x] I have mentioned the issue number in my Pull Request. *(N/A if no issue)*  
- [x] I have gone through the `CONTRIBUTING.md` file before contributing  
- [x] I have performed a self-review of my own code.  
- [x] I have tested the changes thoroughly before submitting this pull request.  
- [x] I have provided relevant issue numbers and screenshots after making the changes.
