### PR TITLE
fix: add shadows to feature cards in dark mode

### DIFF
--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -49,13 +49,13 @@
 .featureCard {
   background: #fff;
   border-radius: 1rem;
-  box-shadow: 0 4px 24px 0 rgba(30, 41, 59, 0.08);
   padding: 2rem 1.5rem 1.5rem 1.5rem;
   text-align: center;
-  transition: box-shadow 0.3s, transform 0.3s;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 .featureCard:hover {
-  box-shadow: 0 8px 32px 0 rgba(30, 41, 59, 0.16);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   transform: translateY(-6px);
 }
 
@@ -108,11 +108,11 @@
 [data-theme='dark'] .featureCard {
   background: #23272f;
   color: #f3f4f6;
-  box-shadow: 0 4px 24px 0 rgba(0,0,0,0.32);
+   box-shadow: 0 2px 6px rgba(255, 255, 255, 0.05);
 }
 
 [data-theme='dark'] .featureCard:hover {
-  box-shadow: 0 8px 32px 0 rgba(0,0,0,0.48);
+  box-shadow: 0 4px 12px rgba(255, 255, 255, 0.1);
 }
 
 [data-theme='dark'] .featureTitle {


### PR DESCRIPTION
# Related Issue
Fixes #159

## Description
In dark mode, the "Why Choose LearnHub" feature cards didn’t have shadows, making them blend into the background.
This PR adds subtle shadows in dark mode to improve readability, visual hierarchy, and consistency with light mode design.

Fixes # (issue number)

# Type of PR
- [x] Feature enhancement

# Screenshots / videos (if applicable)
Before:
<img width="1365" height="673" alt="Screenshot 2025-08-20 204433" src="https://github.com/user-attachments/assets/2aefb8a6-4121-41cf-b526-2a259e4b9329" />
After:
<img width="1315" height="551" alt="Screenshot 2025-08-20 210008" src="https://github.com/user-attachments/assets/73253c14-82b1-41bb-8376-c334a4e9dff8" />

Before:
<img width="1365" height="673" alt="Screenshot 2025-08-20 204433" src="https://github.com/user-attachments/assets/ca21197f-7c75-4b2b-87e5-3a061f014399" />
After:
<img width="698" height="606" alt="Screenshot 2025-08-20 204849" src="https://github.com/user-attachments/assets/2f31f2aa-80e2-4f0a-9374-aec4033cbde9" />
<img width="1365" height="673" alt="Screenshot 2025-08-20 204433" src="https://github.com/user-attachments/assets/be35dac9-db59-48aa-b2f5-e89fc758cb41" />

## Checklist:

- [x] I have made this change from my own.
- [x] I have mentioned the issue number in my Pull Request.
- [x] I have gone through the `CONTRIBUTING.md` file before contributing
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

