### PR TITLE
fix: Improve Text Visibility in Light Mode (Theme Issue)

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,5 +1,21 @@
+/*fixed code of text visibility for theme */
+
+:root {
+  /* Light mode defaults */
+  --hero-text-color: #111827; /* Dark gray for good readability */
+  --hero-badge-gradient: linear-gradient(to right, #14b8a6, #0284c7); /* Teal/blue */
+  --hero-highlight-gradient: linear-gradient(to right, #16a34a, #15803d); /* Green */
+}
+
+[data-theme='dark'] {
+  /* Override for dark mode */
+  --hero-text-color: #f9fafb; /* Near white */
+  --hero-badge-gradient: linear-gradient(to right, #2dd4bf, #0ea5e9); /* Brighter teal/blue */
+  --hero-highlight-gradient: linear-gradient(to right, #4ade80, #22c55e); /* Brighter green */
+}
+
+
 .heroBanner {
-  /* background-color: var(--ifm-hero-background-color); */
   padding: 2rem 2rem;
   display: flex;
   align-items: center;
@@ -7,6 +23,8 @@
   min-height: 80vh;
   position: relative;
   z-index: 0;
+  background-color: var(--ifm-background-color);
+  color: var(--hero-text-color);
 }
 
 .heroContentWrapper {
@@ -30,8 +48,8 @@
 }
 
 .heroBadge {
-  background: linear-gradient(to right, #2dd4bf, #0ea5e9);
-  color: white;
+  background: var(--hero-badge-gradient);
+  color: #fff;
   padding: 0.8rem 0.6rem;
   border-radius: 9999px;
   font-weight: bold;
@@ -40,20 +58,21 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-  
 }
 
 .heroTitle {
   font-size: 3.5rem;
   font-weight: 700;
   line-height: 1.2;
+  color: var(--hero-text-color);
 }
 
 .highlightGreen {
-  background: linear-gradient(to right, #4ade80, #22c55e);
+  background: var(--hero-highlight-gradient);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
+
 
 .heroCerts {
   font-weight: 600;
@@ -64,6 +83,8 @@
   color: #0ea5e9;
   text-decoration: underline;
 }
+
+
 
 /* .heroSubtitle {
   color: var(--ifm-font-color-base);


### PR DESCRIPTION
### Related Issue
Fixes #228
### Description
This PR improves the text visibility styles by applying theme-aware gradients to ensure proper contrast and accessibility in both Light Mode and Dark Mode.
Previously, the text visibility in Light Mode had low contrast, making text difficult to read. With this change:
-Primary text background uses the updated gradient (--hero-badge-gradient).
-Hover state applies a green highlight gradient (--hero-highlight-gradient).
-Text color remains clearly visible (#fff) across both modes (In Buttons).

Fixes #228 

### Type of PR
-Bug fix

###After Changes
https://drive.google.com/file/d/1075FM7BE4QvCCbI_eB__Rpzqn9lsqVmW/view?usp=sharing

